### PR TITLE
Add rack cli usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ heat stack-create -t 240 \
   <stack-name>
 ```
 
+or
+
+```
+rack orchestration stack create --name <stack-name> \
+  --template-file templates/rpc-<template-name>.yml \
+  --environment-file environments/rpc-<environment-name>.yml \
+  --timeout 240
+```
+
 ### Build Status
 
 | Deployment                                                                                      | Release           | Patched Builds *                                                                                                    | Unpatched Builds *                                                                                                              |


### PR DESCRIPTION
This makes things a little easier for people already using the Rackspace CLI for Rackspace Public Cloud. python-heatclient has a few quirks interacting with Rackspace Public Cloud that the rack cli is able to avoid.
