### PR TITLE
Add libssl-dev to list of dependencies

### DIFF
--- a/templates/rpc-full.yml
+++ b/templates/rpc-full.yml
@@ -211,6 +211,7 @@ resources:
           - python-apt
           - python-dev
           - libffi-dev
+          - libssl-dev
         write_files:
           - path: /opt/cloud-training/id_rsa
             permissions: "0600"


### PR DESCRIPTION
This is also necessary for cryptography to install properly. It compiles against openssl and libffi and thus needs headers for both.
